### PR TITLE
Add multiple data streams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 )
 
-require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+require golang.org/x/sys v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,9 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"context"
+	"os"
+
 	"arkis_test/database"
 	"arkis_test/processor"
 	"arkis_test/queue"
-	"context"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -25,5 +26,8 @@ func main() {
 
 	log.Info("Application is ready to run")
 
-	processor.New(inputQueue, outputQueue, database.D{}).Run(ctx)
+	err = processor.New(inputQueue, outputQueue, database.D{}).Run(ctx)
+	if err != nil {
+		log.WithError(err).Error("Running processor")
+	}
 }

--- a/main.go
+++ b/main.go
@@ -2,32 +2,77 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
 
 	"arkis_test/database"
 	"arkis_test/processor"
 	"arkis_test/queue"
-
-	log "github.com/sirupsen/logrus"
 )
+
+type stream struct {
+	inputQueueName  string
+	outputQueueName string
+	database        processor.Database
+}
+
+var streams = map[string]stream{
+	"A": {
+		inputQueueName:  "input-A",
+		outputQueueName: "output-A",
+		database:        database.D{},
+	},
+	"B": {
+		inputQueueName:  "input-B",
+		outputQueueName: "output-B",
+		database:        database.D{},
+	},
+}
 
 func main() {
 	ctx := context.Background()
 
-	inputQueue, err := queue.New(os.Getenv("RABBITMQ_URL"), "input-A")
-	if err != nil {
-		log.WithError(err).Panic("Cannot create input queue")
-	}
-
-	outputQueue, err := queue.New(os.Getenv("RABBITMQ_URL"), "output-A")
-	if err != nil {
-		log.WithError(err).Panic("Cannot create output queue")
+	rabbitURL := os.Getenv("RABBITMQ_URL")
+	if rabbitURL == "" {
+		log.Panic("RABBITMQ_URL environment variable not set")
 	}
 
 	log.Info("Application is ready to run")
 
-	err = processor.New(inputQueue, outputQueue, database.D{}).Run(ctx)
+	err := startStreamProcessors(ctx, rabbitURL)
 	if err != nil {
-		log.WithError(err).Error("Running processor")
+		log.WithField("reason", err).Info("Exiting")
 	}
+}
+
+func startStreamProcessors(ctx context.Context, connectionURL string) error {
+	wg := sync.WaitGroup{}
+	for strName, str := range streams {
+		wg.Add(1)
+		go func(name string, s stream) {
+			defer wg.Done()
+
+			inputQueue, err := queue.New(connectionURL, s.inputQueueName)
+			if err != nil {
+				log.WithError(err).Errorf("Create input queue for stream %s", name)
+				return
+			}
+			outputQueue, err := queue.New(connectionURL, s.outputQueueName)
+			if err != nil {
+				log.WithError(err).Errorf("Create output queue for stream %s", name)
+				return
+			}
+			err = processor.New(inputQueue, outputQueue, s.database).Run(ctx)
+			if err != nil {
+				log.WithError(err).Errorf("Running processor for stream %s", name)
+				return
+			}
+		}(strName, str)
+	}
+
+	wg.Wait()
+	return fmt.Errorf("all processors failed")
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"fmt"
 
 	"arkis_test/queue"
 
@@ -39,7 +40,7 @@ func (p Processor) Run(ctx context.Context) error {
 			return ctx.Err()
 		case delivery := <-deliveries:
 			if err := p.process(ctx, delivery); err != nil {
-				return err
+				return fmt.Errorf("process delivery: %w", err)
 			}
 		}
 	}
@@ -50,7 +51,7 @@ func (p Processor) process(ctx context.Context, delivery queue.Delivery) error {
 
 	data, err := p.database.Get(delivery.Body)
 	if err != nil {
-		return err
+		return fmt.Errorf("get data: %w", err)
 	}
 
 	log.WithField("result", data).Info("Processed the delivery")

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,8 +1,9 @@
 package processor
 
 import (
-	"arkis_test/queue"
 	"context"
+
+	"arkis_test/queue"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -16,17 +17,17 @@ type Database interface {
 	Get([]byte) (string, error)
 }
 
-type processor struct {
+type Processor struct {
 	input    Queue
 	output   Queue
 	database Database
 }
 
-func New(input, output Queue, db Database) processor {
-	return processor{input, output, db}
+func New(input, output Queue, db Database) Processor {
+	return Processor{input, output, db}
 }
 
-func (p processor) Run(ctx context.Context) error {
+func (p Processor) Run(ctx context.Context) error {
 	deliveries, err := p.input.Consume(ctx)
 	if err != nil {
 		return err
@@ -44,7 +45,7 @@ func (p processor) Run(ctx context.Context) error {
 	}
 }
 
-func (p processor) process(ctx context.Context, delivery queue.Delivery) error {
+func (p Processor) process(ctx context.Context, delivery queue.Delivery) error {
 	log.WithField("delivery", string(delivery.Body)).Info("Processing the delivery")
 
 	data, err := p.database.Get(delivery.Body)
@@ -52,7 +53,7 @@ func (p processor) process(ctx context.Context, delivery queue.Delivery) error {
 		return err
 	}
 
-	log.WithField("result", string(data)).Info("Processed the delivery")
+	log.WithField("result", data).Info("Processed the delivery")
 
 	return p.output.Publish(ctx, []byte(data))
 }

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -12,13 +12,13 @@ type Delivery struct {
 	handler amqp.Delivery
 }
 
-type queue struct {
+type Queue struct {
 	amqpConnection *amqp.Connection
 	channel        *amqp.Channel
 	name           string
 }
 
-func New(connectionURL, queueName string) (*queue, error) {
+func New(connectionURL, queueName string) (*Queue, error) {
 	conn, err := amqp.Dial(connectionURL)
 	if err != nil {
 		return nil, err
@@ -41,10 +41,10 @@ func New(connectionURL, queueName string) (*queue, error) {
 		return nil, err
 	}
 
-	return &queue{conn, ch, queueName}, nil
+	return &Queue{conn, ch, queueName}, nil
 }
 
-func (queue *queue) Consume(ctx context.Context) (<-chan Delivery, error) {
+func (queue *Queue) Consume(ctx context.Context) (<-chan Delivery, error) {
 	deliveries, err := queue.channel.ConsumeWithContext(
 		ctx,
 		queue.name,
@@ -76,7 +76,7 @@ func (queue *queue) Consume(ctx context.Context) (<-chan Delivery, error) {
 	return out, nil
 }
 
-func (queue *queue) Publish(ctx context.Context, msg []byte) error {
+func (queue *Queue) Publish(ctx context.Context, msg []byte) error {
 	data := amqp.Publishing{
 		DeliveryMode:    amqp.Transient,
 		Timestamp:       time.Now(),

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -21,12 +22,12 @@ type Queue struct {
 func New(connectionURL, queueName string) (*Queue, error) {
 	conn, err := amqp.Dial(connectionURL)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("dial: %w", err)
 	}
 
 	ch, err := conn.Channel()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open channel: %w", err)
 	}
 
 	_, err = ch.QueueDeclare(
@@ -38,7 +39,7 @@ func New(connectionURL, queueName string) (*Queue, error) {
 		nil,       // arguments
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("declare queue: %w", err)
 	}
 
 	return &Queue{conn, ch, queueName}, nil
@@ -56,7 +57,7 @@ func (queue *Queue) Consume(ctx context.Context) (<-chan Delivery, error) {
 		nil,   // args
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("retrieved queued messages: %w", err)
 	}
 
 	out := make(chan Delivery)


### PR DESCRIPTION
Enable a fault-tolerant approach on a variable number of data streams. The application will only exit when there's no processor running. Data streams can be defined by adding them to the `streams` map.