### PR TITLE
Add support for the second stream of data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .DEFAULT_GOAL := app
 app:
 	docker compose down && docker compose up --build
+demo-client:
+	go run cmd/client/main.go -input=input-B -output=output-B
 lint:
 	gofmt -w -s . && go mod tidy && go vet ./...

--- a/README.md
+++ b/README.md
@@ -5,21 +5,42 @@ Upon delivery service processes it (basically does `{"result": " + string(input)
 Processed message is being published to default exchange with routing key `output-A`.
 
 ### Black box
-Client publishes 'hello' to `input-A` and receives '{"result": "hello"}' from `output-A`.
 
+Client publishes 'hello' to `input-A` and receives '{"result": "hello"}' from `output-A`.
 
 ## How to
 
 ### Lint
+
 Format the code, fix dependencies and validate the project.
+
 ```bash
 make lint
 ```
 
 ### Run
+
 Bootstrap RabbitMQ, run the service and start processing messages received from the queue.
+
 ```bash
 make
+```
+
+### Run demo client
+
+Run demo client that waits for user input and publishes messages to queue `input-B` and consumes from the queue `output-B`.
+
+```bash
+make demo-client
+```
+
+Example output
+
+```text
+hello
+[recv]  {"result": "hello"}
+bye
+[recv]  {"result": "bye"}
 ```
 
 ## Objective
@@ -27,5 +48,6 @@ make
 Add support for the second stream of data using `input-B` and `output-B` queues.
 
 ### Black box
+
 1. Client publishes 'hello' to `input-A` and receives '{"result": "hello"}' from `output-A`.
 2. Client publishes 'hello' to `input-B` and receives '{"result": "hello"}' from `output-B`.

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"arkis_test/queue"
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	address     = flag.String("address", "amqp://localhost:5672", "rabbitmq address")
+	inputQueue  = flag.String("input", "", "name of the queue to pulish messages to")
+	outputQueue = flag.String("output", "", "name of the queue to read messages from")
+)
+
+func main() {
+	flag.Parse()
+
+	if *inputQueue == "" && *outputQueue == "" {
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	wg := sync.WaitGroup{}
+
+	if *inputQueue != "" {
+		publisher, err := queue.New(*address, *inputQueue)
+		if err != nil {
+			logrus.WithError(err).Panic("Cannot create input queue")
+		}
+
+		scanner := bufio.NewScanner(os.Stdin)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for scanner.Scan() {
+				message := scanner.Bytes()
+				if err = publisher.Publish(context.Background(), message); err != nil {
+					logrus.WithError(err).Error("failed to publish message")
+					return
+				}
+			}
+
+			if err = scanner.Err(); err != nil {
+				logrus.WithError(err).Error("error scanning input")
+			}
+		}()
+
+	}
+
+	if *outputQueue != "" {
+		consumer, err := queue.New(*address, *outputQueue)
+		if err != nil {
+			logrus.WithError(err).Panic("Cannot create input queue")
+		}
+
+		messages, err := consumer.Consume(context.Background())
+		if err != nil {
+			logrus.WithError(err).Panic("failed to consume messages")
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for message := range messages {
+				fmt.Fprintln(os.Stdout, "[recv] ", string(message.Body))
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
This PR:

1. Adds support for the second stream of data using input-B and output-B queues.
2. Adds demo client that can publish and consume from specified queues.
3. Adds Makefile command to run pre-configured demo client that utilizes B queues.